### PR TITLE
bugfix: ./mvnw test Permission denied

### DIFF
--- a/demo/tekton-pipeline.yaml
+++ b/demo/tekton-pipeline.yaml
@@ -28,4 +28,5 @@ spec:
               cd `mktemp -d`
 
               wget -qO- $(params.source-url) | tar xvz
+              chmod a+x ./mvnw
               ./mvnw test


### PR DESCRIPTION
Tanzu workload with label `apps.tanzu.vmware.com/has-tests=true` run through failed with "./mvnw Permission Denied".