### PR TITLE
Update tap-values.yaml

### DIFF
--- a/tap-values.yaml
+++ b/tap-values.yaml
@@ -51,7 +51,7 @@ contour:
       type: LoadBalancer
 
 accelerator: 
-  domain: #@ "accelerator.{}".format(data.values.ingress.domain)                         
+  domain: #@ "{}".format(data.values.ingress.domain)                         
   ingress:
     include: true
   tls:


### PR DESCRIPTION
Remove `accelerator.` from the yaml because the target URL is `accelerator.accelerator.<FQDN>` which is wrong.